### PR TITLE
Remove "Network" path as required dir to run automactc.py on mounted …

### DIFF
--- a/automactc.py
+++ b/automactc.py
@@ -484,7 +484,7 @@ if __name__ == "__main__":
 
     # Confirm that mount point in forensic mode has required directories - to see if the volume is actually mounted.
     mount_test = glob.glob(os.path.join(inputdir,'*'))
-    required_dirs = ['Library', 'System', 'Users', 'Applications', 'Network']
+    required_dirs = ['Library', 'System', 'Users', 'Applications']
     litmus = [i for i in mount_test if any(i.endswith(d) for d in required_dirs)]
     if len(litmus) < len(required_dirs) and forensic_mode and override_mount is False:
         print( "Mount point doesn't have any of the expected directories underneath. Check if the mount was completed successfully.")


### PR DESCRIPTION
…image

"Network" path does not exist as an actual path on root for an OSX. Also, not everyone will have a network share or path mounted. Having this check essentially makes it impossible to run the automactc.py on a mounted image without removing that check. The current required_dirs seem sufficient to identify a typical OSX filesystem, however other directories could be added (They will be hidden) such as "private", "usr", or "sbin".